### PR TITLE
Rcpp fmatch with no copying to C strings

### DIFF
--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -6,13 +6,13 @@
 using namespace Rcpp;
 
 // fmatch
-IntegerVector fmatch(std::vector< std::string > x, std::vector< std::string > y);
+IntegerVector fmatch(const std::vector< std::string >& x, const std::vector< std::string >& y);
 RcppExport SEXP _fmatch_fmatch(SEXP xSEXP, SEXP ySEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< std::vector< std::string > >::type x(xSEXP);
-    Rcpp::traits::input_parameter< std::vector< std::string > >::type y(ySEXP);
+    Rcpp::traits::input_parameter< const std::vector< std::string >& >::type x(xSEXP);
+    Rcpp::traits::input_parameter< const std::vector< std::string >& >::type y(ySEXP);
     rcpp_result_gen = Rcpp::wrap(fmatch(x, y));
     return rcpp_result_gen;
 END_RCPP


### PR DESCRIPTION
I wrote a Rcpp version of fmatch that doesn't require copying the C++ strings to C-style strings. It passes all tests but does not seem to offer a performance improvement (the vignette graphs looks very similar).

I had to do a quick review of how C++ and C style strings work / interact in order to write this. Let me summarize what I learned. I think that this will summary will make the code review for you to understand my code.

The following are C++ strings:
````
std::string x = "asdf";
"a"; // Note the double-quote
````
The following are C strings:
````
std::string x = "asdf";  
x[1]; // ([] returns "C Style String")

'?'; // Note the single quote
````
You can compare two C style strings by combining [] and ''. For example:
````
std::string x = "asdf";
x[1] == '?';
````
But you **cannot** compare a C Style String and a C++ String:
````
std::string x = "asdf";
x[1] == "?";
````
The error you get is "ISO C++ forbids comparison between pointer and integer." 

The language I am using to describe this might be somewhat inaccurate, in that I am saying "C string" and "C++ string" and the compiler is saying "pointer" and "integer". But I think that my language might be more useful for helping a human to understand what they actually need to do and why.

Once you realize that you can iterate over C++ strings using a loop and [], and compare the contents to single character within single quotes (e.g. '?'), the problem gets easy to solve.

Another thing I want to point out in this PR is the use of "const reference" for all parameters. By passing by reference `&` we eliminate a copying of the variable. This is a performance improvement, but is dangerous by itself: the caller might not want their variable changed. We solve this by making the parameter a `const` reference: this forces the compiler to emit an error if the variable is changed. 

This is a very common optimization in C++. When I worked on a large C++ project, this was probably the "default" way to pass function parameters. I recommend we adapt this practice here as well, because it is an easy performance improvement with virtually no downside. 